### PR TITLE
refactor/authorization-dead-code

### DIFF
--- a/app/routers/order.py
+++ b/app/routers/order.py
@@ -7,7 +7,7 @@ from typing import List
 from enum import Enum
 from app.schemas.Order import OrderResponse
 from app.services.session_manager_service import get_user_from_session
-from app.services.authorization_service import require_role_multi_service, require_role_service
+from app.services.authorization_service import require_role_service
 from app.schemas.Token import Token
 
 router = APIRouter(prefix="/orders", tags=["orders"])
@@ -73,7 +73,7 @@ def cancel_order_restaurant(order_id:str,token: str = Header(...)):
     """
     session = Token(token=token)
     current_user = get_user_from_session(session)
-    require_role_multi_service(current_user, [UserRole.MANAGER, UserRole.OWNER])
+    require_role_service(current_user, UserRole.STAFF)
     # TODO: check if user_id from session is in get_staff_by_restaurant
     return cancel_order_restaurant_service(order_id)
 
@@ -85,6 +85,6 @@ def accept_order(order_id:str,token: str = Header(...)):
     """
     session = Token(token=token)
     current_user = get_user_from_session(session)
-    require_role_multi_service(current_user, [UserRole.MANAGER, UserRole.OWNER])
+    require_role_service(current_user, UserRole.STAFF)
     # TODO: check if user_id from session is in get_staff_by_restaurant
     return accept_order_service(order_id)

--- a/app/services/authorization_service.py
+++ b/app/services/authorization_service.py
@@ -18,10 +18,3 @@ def require_role_service(user: UserResponse, role: UserRole):
     Output: none"""
     if user.role != role:
         raise HTTPException(status_code=403, detail="Unauthorized")
-    
-def require_role_multi_service(user: UserResponse, roles: list[UserRole]):
-    """Used to check if a user has a specific role from a list and raises forbidden exception if not. 
-    Input: a list of UserResponse.
-    Output: none"""
-    if user.role not in roles:
-        raise HTTPException(status_code=403, detail="Unauthorized")

--- a/test/test_routers/test_order.py
+++ b/test/test_routers/test_order.py
@@ -124,7 +124,7 @@ def mock_staff_response():
         email="pippin@example.com",
         first_name="peregrin",
         last_name="took",
-        role=UserRole.OWNER,
+        role=UserRole.STAFF,
         created_date=datetime(2026, 2, 20, 12, 34, 56))
       
 @pytest.fixture

--- a/test/test_services/test_authorization_service.py
+++ b/test/test_services/test_authorization_service.py
@@ -34,7 +34,7 @@ def test_require_role_service_success(mocker):
     result = require_role_service(mock_user, UserRole.CUSTOMER)
     assert result is None
 
-def test_require_role_service_success(mocker):
+def test_require_role_service_fail(mocker):
     """tests that require_role_service raises an exception if user does not have required role"""
     mock_user = mocker.Mock()
     mock_user.role = UserRole.CUSTOMER
@@ -42,26 +42,3 @@ def test_require_role_service_success(mocker):
     with pytest.raises(HTTPException) as testException: require_role_service(mock_user, UserRole.OWNER)
     assert testException.value.status_code ==403
     
-def require_role_multi_service_sucess(mocker):
-    """tests that require_role_multi_service returns None if user's role matches a role in the supplied list"""
-    mock_user = mocker.Mock()
-    mock_user.role = UserRole.CUSTOMER
-    
-    result = require_role_service(mock_user, [UserRole.CUSTOMER, UserRole.STAFF])
-    assert result is None
-    
-def require_role_multi_service_fail(mocker):
-    """tests that require_role_multi_service raises an exception if user does not have a role from supplied list"""
-    mock_user = mocker.Mock()
-    mock_user.role = UserRole.CUSTOMER
-    
-    with pytest.raises(HTTPException) as testException: require_role_service(mock_user, [UserRole.OWNER, UserRole.STAFF])
-    assert testException.value.status_code ==403
-    
-def require_role_multi_service_fail(mocker):
-    """tests that require_role_multi_service raises an exception if user does not have a role from an empty list"""
-    mock_user = mocker.Mock()
-    mock_user.role = UserRole.CUSTOMER
-    
-    with pytest.raises(HTTPException) as testException: require_role_service(mock_user, [])
-    assert testException.value.status_code ==403


### PR DESCRIPTION
 I had previously written a method to check a user's role against a list of roles, intended for checking if a role could be STAFF, MANAGER, or OWNER. We redesigned roles, and now user roles are only ever CUSTOMER or STAFF, and OWNER/MANAGER/COURIER are separate staff assignments. Since this feature wasn't needed, I removed the code and tests. I also removed references to it in order router integration tests.